### PR TITLE
add pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,16 @@ install(
   DIRECTORY include/makestuff DESTINATION include
 )
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libusbwrap.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libusbwrap.pc
+@ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/libusbwrap.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)
+
 # List endpoints tool
 add_subdirectory(lsep)
 

--- a/libusbwrap.pc.in
+++ b/libusbwrap.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: libusbwrap
+Description: A thin wrapper around LibUSB (http://libusb.org).
+Requires: common liberror libusb-1.0
+Version: 20170708
+Libs: -L${libdir} -lerror
+Cflags: -I${includedir}
+


### PR DESCRIPTION
One classic way to detect and to obtain required parameters at build time requirements, to use a library, is through `pkg-config`.
This approach allows to fill FLAGS and LIBS with respect of dependencies (in this specific case `liberror`, `common` and `libusb1`)
This approach is Linux and msys2 compatible.
This PR add a pc.in file filled with prefix and all required informations, this one is installed in `${CMAKE_INSTALL_LIBDIR}/pkgconfig`